### PR TITLE
Move dependencies to development block

### DIFF
--- a/template/{{serviceRole}}/service.yml
+++ b/template/{{serviceRole}}/service.yml
@@ -22,17 +22,17 @@ messages:
     - {{modelName}}.details
     - {{modelName}}.updated
 
-dependencies:
-  - name: 'mongo'
-    version: '3.4.0'
-    config:
-      volumes:
-        - '{{EXO_DATA_PATH}}:/data/db'
-      ports:
-        - '27017:27017'
-      online-text: 'waiting for connections'
 
 development:
   scripts:
     run: node src/server.js
     test: node_modules/cucumber/bin/cucumber.js
+  dependencies:
+    - name: 'mongo'
+      version: '3.4.0'
+      config:
+        volumes:
+          - '{{EXO_DATA_PATH}}:/data/db'
+        ports:
+          - '27017:27017'
+        online-text: 'waiting for connections'


### PR DESCRIPTION
Someone was working on the todo tutorial and ran into an outdated template. How are we handling updating these templates as we release exosphere? 